### PR TITLE
build: attempt to fix package lock sync for samples via npm i on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,7 @@ jobs:
       - run:
           command: |
             cd << parameters.clone_path >>
+            npm i
             git add -A
             git status --short
 

--- a/packages/samples/package-lock.json
+++ b/packages/samples/package-lock.json
@@ -78,18 +78,18 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.500.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.500.1.tgz",
-      "integrity": "sha512-kN8irxVqSx2N+wQYsmvntzDmCPYQOtESAHkKMPzQ25BXi2oWWq+Ee/LziRF2O4OXwOxwmazBl8LwA5wHsg4IZA=="
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.501.0.tgz",
+      "integrity": "sha512-vu8U76EINHfww4eYZ2lXHttzlO1RWBbta7cW5+0c1n1Quq3jDu4yGSgy7I5ztRTFT8L18Yw0alfnpbagiHbKnQ=="
     },
     "@conversationlearner/sdk": {
-      "version": "0.500.2",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.500.2.tgz",
-      "integrity": "sha512-8X1HAJNo5SM5xFmVYCFcjWtpn7+yhwGMhMTCI6tzHMX6BgWcDqH7ym4NXNr7nUhh3ifAymv2A9w0ICAYcRt76Q==",
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.501.0.tgz",
+      "integrity": "sha512-Q6a7CkE1mTepTPRM7x7VAAiGp1EZGmUPSIxVqUdgQ6yMdn/gaCRJ7v5tZpeWzKErxLFgKgZ/gmQlYtdxxn1Bug==",
       "requires": {
         "@azure/cosmos": "^3.3.6",
-        "@conversationlearner/models": "^0.500.1",
-        "@conversationlearner/ui": "^0.500.2",
+        "@conversationlearner/models": "^0.501.0",
+        "@conversationlearner/ui": "^0.501.0",
         "@types/supertest": "2.0.4",
         "async-file": "^2.0.2",
         "body-parser": "1.18.3",
@@ -168,9 +168,9 @@
       }
     },
     "@conversationlearner/ui": {
-      "version": "0.500.2",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.500.2.tgz",
-      "integrity": "sha512-VAiXb4cgntmCcQBpIjlwvCxuVsVkI1SlHmqW27dYnOMEJM+TxMaGI4pKowJy76X35jVV9HX98Re6kVJS7zmjuA=="
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.501.0.tgz",
+      "integrity": "sha512-vzSuNCWBr5nCjCYSB5g2H6YmB358CGL5E52HBSc9QlAK8Jr6VwiGFRsvzpTDvo/nRgddmsN/HKefQpBaD6U9sg=="
     },
     "@kyleshockey/object-assign-deep": {
       "version": "0.4.2",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -536,14 +536,14 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.500.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.500.1.tgz",
-      "integrity": "sha512-kN8irxVqSx2N+wQYsmvntzDmCPYQOtESAHkKMPzQ25BXi2oWWq+Ee/LziRF2O4OXwOxwmazBl8LwA5wHsg4IZA=="
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.501.0.tgz",
+      "integrity": "sha512-vu8U76EINHfww4eYZ2lXHttzlO1RWBbta7cW5+0c1n1Quq3jDu4yGSgy7I5ztRTFT8L18Yw0alfnpbagiHbKnQ=="
     },
     "@conversationlearner/ui": {
-      "version": "0.500.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.500.1.tgz",
-      "integrity": "sha512-x17kyIwqNa3qUN8CosTk/mmXeXDxZyGl+xp7qVgCEzi3r25/HdhVMj65/8siCAVGFFFxyUufjnaZsCwdGBhLvQ=="
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.501.0.tgz",
+      "integrity": "sha512-vzSuNCWBr5nCjCYSB5g2H6YmB358CGL5E52HBSc9QlAK8Jr6VwiGFRsvzpTDvo/nRgddmsN/HKefQpBaD6U9sg=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1773,14 +1773,14 @@
       }
     },
     "@conversationlearner/models": {
-      "version": "0.500.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.500.1.tgz",
-      "integrity": "sha512-kN8irxVqSx2N+wQYsmvntzDmCPYQOtESAHkKMPzQ25BXi2oWWq+Ee/LziRF2O4OXwOxwmazBl8LwA5wHsg4IZA=="
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/models/-/models-0.501.0.tgz",
+      "integrity": "sha512-vu8U76EINHfww4eYZ2lXHttzlO1RWBbta7cW5+0c1n1Quq3jDu4yGSgy7I5ztRTFT8L18Yw0alfnpbagiHbKnQ=="
     },
     "@conversationlearner/webchat": {
-      "version": "0.500.1",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/webchat/-/webchat-0.500.1.tgz",
-      "integrity": "sha512-+WFqxZXN5cap5wrPnM8kwqU+D0EFM7rLOUKafAWf/j7SugmfMT3BAdVovTqr+nyL5UlEgM+rwAvnNgSCkd5k/Q==",
+      "version": "0.501.0",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/webchat/-/webchat-0.501.0.tgz",
+      "integrity": "sha512-2aMLxDVI6bSVXIh90csBYw/fcxgY2QVMMkq0i+WyLdY1WoBSNktc9dVNk/2pzRZCo9wTG4J7Rqosph+ORgz72Q==",
       "requires": {
         "adaptivecards": "1.2.0",
         "botframework-directlinejs": "0.9.17",


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Bug

#### What's the new behavior?
Adds `npm i` to the script to try to force these to be in sync.  

#### How does this change work?
Seems now that were pushing to actual samples repo which has builds instead of my separate person repos we're seeing package-lock sync issues. Looks like lerna updates the root versions but not the install versions ins the `package-lock.json`.  Might be another reason to look at manual releasing of samples.

Not sure what the correct behavior should be regarding version updating.

### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @