### PR TITLE
Wait for Chat Message Update

### DIFF
--- a/packages/ui/cypress/integration/Regression/ErrorHandling/ApiCreateMultipleExceptions.spec.js
+++ b/packages/ui/cypress/integration/Regression/ErrorHandling/ApiCreateMultipleExceptions.spec.js
@@ -14,7 +14,7 @@ import * as helpers from '../../../support/Helpers'
 // SKIPPING this test due to Bug 2389: Entity Detection stutters as it repeats the user's utterance many times
 
 // This test suite is part 1 of 2. The second part is in ApiVerifyMultipleExceptions.
-describe.skip('API Create Multiple Exceptions - ErrorHandling', () => {
+describe('API Create Multiple Exceptions - ErrorHandling', () => {
   afterEach(helpers.SkipRemainingTestsOfSuiteIfFailed)
 
   context('Setup', () => {
@@ -119,7 +119,7 @@ describe.skip('API Create Multiple Exceptions - ErrorHandling', () => {
     })
 
     it('Should add a user turn with an Entiy error, verify popup, confirm popup, and verify user turn is removed', () => {
-      train.TypeYourMessage('This entityError will cause the user turn to be discarded.', true)
+      train.TypeYourMessage('This entityError will cause the user turn to be discarded.', undefined, true)
       entityDetectionPanel.LabelTextAsEntity('entityError', 'entityError')
       train.ClickScoreActionsButton()
       train.VerifyErrorPopup("Error in Bot's EntityDetectionCallback:  An intentional error was invoked in the EntityDetectionCallback function.")

--- a/packages/ui/cypress/support/Helpers.js
+++ b/packages/ui/cypress/support/Helpers.js
@@ -54,6 +54,22 @@ export function RemoveDuplicates(inputArray) {
   return uniqueOutputArray
 }
 
+// This will return an array of the Inner Text (with New Lines removed) of an array of elements.
+// Pass in either an array of elements or the selector to get the array of elements with.
+export function ArrayOfTextContentWithoutNewlines(elementsOrSelector) {
+  if (elementsOrSelector === undefined || elementsOrSelector.length == 0) { return undefined }
+
+  let elements
+  if (typeof elementsOrSelector == 'string') { elements = Cypress.$(elementsOrSelector) }
+  else { elements = elementsOrSelector }
+
+  let arrayOfTextContent = []
+  for (let i = 0; i < elements.length; i++) {
+    arrayOfTextContent.push(TextContentWithoutNewlines(elements[i]))
+  }
+  return arrayOfTextContent
+}
+
 export function StringArrayFromElementText(selector, retainMarkup = false) {
   let funcName = `StringArrayFromElementText(${selector})`
   let elements = Cypress.$(selector)
@@ -111,22 +127,6 @@ export function TextContentWithoutNewlines(element) {
     .replace(/([^◾️…\x20-\x7E])/gm, '')
   ConLog('TextContentWithoutNewlines', `"${returnValue}"`)
   return returnValue
-}
-
-// This will return an array of the Inner Text (with New Lines removed) of an array of elements.
-// Pass in either an array of elements or the selector to get the array of elements with.
-export function ArrayOfTextContentWithoutNewlines(elementsOrSelector) {
-  if (elementsOrSelector === undefined || elementsOrSelector.length == 0) { return undefined }
-
-  let elements
-  if (typeof elementsOrSelector == 'string') { elements = Cypress.$(elementsOrSelector) }
-  else { elements = elementsOrSelector }
-
-  let arrayOfTextContent = []
-  for (let i = 0; i < elements.length; i++) {
-    arrayOfTextContent.push(TextContentWithoutNewlines(elements[i]))
-  }
-  return arrayOfTextContent
 }
 
 // Model names have a suffix which will end with a single character representing the 

--- a/packages/ui/cypress/support/Train.js
+++ b/packages/ui/cypress/support/Train.js
@@ -217,6 +217,7 @@ export function VerifyCloseIsTheOnlyEnabledButton() {
 
 export function TypeYourMessage(message, expectedTextEntityPairs = undefined, ignoreBotErrorMessages = false) {
   chatPanel.WaitForChatMessageUpdate(() => cy.Get(TypeYourMessageSelector).type(`${message}{enter}`))
+  chatPanel.VerifyTextChatMessage(message)
   entityDetectionPanel.VerifyEntityDetectionPhrase(message)
   if (!ignoreBotErrorMessages) {
     chatPanel.VerifyNoBotErrorAfterUserTurn(message)

--- a/packages/ui/cypress/support/Train.js
+++ b/packages/ui/cypress/support/Train.js
@@ -29,7 +29,7 @@ export function VerifyNoErrorMessage() { cy.DoesNotContain('div.cl-editdialog-er
 export function VerifyErrorPopup(expectedMessage) { cy.Get('p.ms-Dialog-title').ExactMatch(expectedMessage) }
 
 export function ClickPopupConfirmCancelOkButton() { cy.Get('[data-testid="confirm-cancel-modal-ok"]').Click() }
-export function ClickDeleteChatTurn() { cy.Get('[data-testid="chat-edit-delete-turn-button"]').Click() }
+export function ClickDeleteChatTurn() { chatPanel.WaitForChatMessageUpdate(() => chatPanel.ClickDeleteChatTurn()) }
 
 //export function TypeYourMessage(message) { cy.Get(TypeYourMessageSelector).type(`${message}{enter}`) }
 export function VerifyTypeYourMessageIsPresent() { cy.Get(TypeYourMessageSelector) }
@@ -99,27 +99,27 @@ export function AddTags(tags) {
 }
 
 export function SelectTextAction(expectedResponse) {
-  scorerModal.ClickTextAction(expectedResponse)
+  chatPanel.WaitForChatMessageUpdate(() => scorerModal.ClickTextAction(expectedResponse))
   chatPanel.VerifyTextChatMessage(expectedResponse)
 }
 
 export function SelectApiCardAction(apiName, expectedCardTitle, expectedCardText) {
-  scorerModal.ClickApiAction(apiName)
+  chatPanel.WaitForChatMessageUpdate(() => scorerModal.ClickApiAction(apiName))
   chatPanel.VerifyCardChatMessage(expectedCardTitle, expectedCardText)
 }
 
 export function SelectApiPhotoCardAction(apiName, expectedCardTitle, expectedCardText, expectedCardImage) {
-  scorerModal.ClickApiAction(apiName)
+  chatPanel.WaitForChatMessageUpdate(() => scorerModal.ClickApiAction(apiName))
   chatPanel.VerifyPhotoCardChatMessage(expectedCardTitle, expectedCardText, expectedCardImage)
 }
 
 export function SelectApiTextAction(apiName, expectedResponse) {
-  scorerModal.ClickApiAction(apiName)
+  chatPanel.WaitForChatMessageUpdate(() => scorerModal.ClickApiAction(apiName))
   chatPanel.VerifyTextChatMessage(expectedResponse)
 }
 
 export function SelectEndSessionAction(expectedData) {
-  scorerModal.ClickEndSessionAction(expectedData);
+  chatPanel.WaitForChatMessageUpdate(() => scorerModal.ClickEndSessionAction(expectedData))
   chatPanel.VerifyEndSessionChatMessage(expectedData)
 }
 
@@ -216,7 +216,7 @@ export function VerifyCloseIsTheOnlyEnabledButton() {
 }
 
 export function TypeYourMessage(message, expectedTextEntityPairs = undefined, ignoreBotErrorMessages = false) {
-  cy.Get(TypeYourMessageSelector).type(`${message}{enter}`)
+  chatPanel.WaitForChatMessageUpdate(() => cy.Get(TypeYourMessageSelector).type(`${message}{enter}`))
   entityDetectionPanel.VerifyEntityDetectionPhrase(message)
   if (!ignoreBotErrorMessages) {
     chatPanel.VerifyNoBotErrorAfterUserTurn(message)

--- a/packages/ui/cypress/support/components/ChatPanel.js
+++ b/packages/ui/cypress/support/components/ChatPanel.js
@@ -519,12 +519,25 @@ export function VerifyNoBotErrorAfterUserTurn(expectedUserTurnMessage) {
 // This function was introduced late in the game (01/09/2020), and as such there are probably other functions that can
 // benefit from not having to verify that the chat messages are ready to be verified.
 export function WaitForChatMessageUpdate(functionThatWillCauseUpdate) {
-  const countChatMessages = GetAllChatMessageElements().length
+  function AreEqual(strings1, strings2) {
+    if (strings1.length != strings2.length) {
+      return false
+    }
+    for (let i = 0; i < strings1.length; i++) {
+      if (strings1[i] != strings2[i]) {
+        return false
+      }
+    }
+    return true
+  }
+
+  const messagesBeforeUpdate = helpers.StringArrayFromElementText('div[data-testid="web-chat-utterances"]')
   functionThatWillCauseUpdate()
   cy.WaitForStableDOM()
   cy.RetryLoop(() => {
-    if (GetAllChatMessageElements().length == countChatMessages) {
-      throw new Error(`Retry - Waiting for the chat messages to update...when that happens the count of chat messages will not be ${countChatMessages}`)
+    const messagesAfterUpdate = helpers.StringArrayFromElementText('div[data-testid="web-chat-utterances"]')
+    if (AreEqual(messagesAfterUpdate, messagesBeforeUpdate)) {
+      throw new Error(`Retry - Waiting for the chat messages to update`)
     }
   })
 }

--- a/packages/ui/cypress/support/components/ChatPanel.js
+++ b/packages/ui/cypress/support/components/ChatPanel.js
@@ -376,7 +376,7 @@ export function VerifyEachBotChatTurn(verificationFunction) {
 export function VerifyTextChatMessage(expectedMessage, expectedIndexOfMessage) {
   cy.Get('[data-testid="web-chat-utterances"]').then(allChatElements => {
     if (!expectedIndexOfMessage) expectedIndexOfMessage = allChatElements.length - 1
-    const elements = Cypress.$(allChatElements[expectedIndexOfMessage]).find('div.format-markdown > p')
+    const elements = Cypress.$(allChatElements[expectedIndexOfMessage]).find('div.format-markdown > p, span.format-plain > span')
     if (elements.length == 0) {
       throw new Error(`Did not find expected Text Chat Message '${expectedMessage}' at index: ${expectedIndexOfMessage}`)
     }
@@ -395,7 +395,14 @@ export function VerifyTextChatMessage(expectedMessage, expectedIndexOfMessage) {
 // output from the screen or log to paste into your code.
 export function VerifyCardChatMessage(expectedCardTitle, expectedCardText, expectedIndexOfMessage) {
   cy.Get('[data-testid="web-chat-utterances"]').then(allChatElements => {
-    if (!expectedIndexOfMessage) expectedIndexOfMessage = allChatElements.length - 1
+    if (!expectedIndexOfMessage) {
+      expectedIndexOfMessage = allChatElements.length - 1
+      if (Cypress.$(allChatElements[expectedIndexOfMessage]).attr('class').includes('wc-message-color-exception')) {
+        // Sometimes exception messages come after the user turn, this accounts for that fact by setting the index back one more turn.
+        expectedIndexOfMessage--
+      }
+    }
+
     let elements = Cypress.$(allChatElements[expectedIndexOfMessage]).find(`div.format-markdown > p:contains('${expectedCardTitle}')`).parent()
     if (elements.length == 0) {
       throw new Error(`Did not find expected '${expectedCardTitle}' card with '${expectedCardText}' at index: ${expectedIndexOfMessage}`)

--- a/packages/ui/cypress/support/components/ChatPanel.js
+++ b/packages/ui/cypress/support/components/ChatPanel.js
@@ -9,6 +9,7 @@ import * as helpers from '../Helpers'
 
 export function VerifyChatPanelIsDisabled() { cy.Get('div.cl-chatmodal_webchat').find('div.cl-overlay') }
 export function VerifyChatPanelIsEnabled() { cy.Get('div.cl-chatmodal_webchat').DoesNotContain('div.cl-overlay') }
+export function ClickDeleteChatTurn() { cy.Get('[data-testid="chat-edit-delete-turn-button"]').Click() }
 
 export function GetAllChatMessageElements() {
   const elements = Cypress.$('div[data-testid="web-chat-utterances"] > div.wc-message-content > div')
@@ -500,6 +501,23 @@ export function VerifyNoBotErrorAfterUserTurn(expectedUserTurnMessage) {
   }).then(() => {
     if (failureMessage) {
       throw new Error(failureMessage)
+    }
+  })
+}
+
+// Use this function anytime you need to perform some other function that will add to or remove chat messages from
+// the chat panel. This wraps your function call in logic that first gets the current count of chat messages, then
+// performs your function, then it goes into a retry loop waiting for the message count to change.
+//
+// This function was introduced late in the game (01/09/2020), and as such there are probably other functions that can
+// benefit from not having to verify that the chat messages are ready to be verified.
+export function WaitForChatMessageUpdate(functionThatWillCauseUpdate) {
+  const countChatMessages = GetAllChatMessageElements().length
+  functionThatWillCauseUpdate()
+  cy.WaitForStableDOM()
+  cy.RetryLoop(() => {
+    if (GetAllChatMessageElements().length == countChatMessages) {
+      throw new Error(`Retry - Waiting for the chat messages to update...when that happens the count of chat messages will not be ${countChatMessages}`)
     }
   })
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a bug...occasionally some of the tests failed due to new chat messages taking longer than expected to show up in the chat panel or for deleted ones to be removed.

#### What's the new behavior?
I created a wrapper that firsts captures the count of messages in the chat panel, then executes the intended modification function, then waits to see the count change in the chat panel before it allows test execution to proceed.

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @