### PR TITLE
fix: changes to log dialogs list click handler

### DIFF
--- a/packages/ui/src/routes/Apps/App/LogDialogs.tsx
+++ b/packages/ui/src/routes/Apps/App/LogDialogs.tsx
@@ -505,7 +505,7 @@ class LogDialogs extends React.Component<Props, ComponentState> {
                         onColumnHeaderClick={this.onClickColumnHeader}
                         onRenderRow={(props, defaultRender) => <div data-selection-invoke={true}>{defaultRender && defaultRender(props)}</div>}
                         onRenderItemColumn={(logDialog, i, column: IRenderableColumn) => returnErrorStringWhenError(() => column.render(logDialog, this))}
-                        onActiveItemChanged={logDialog => this.onClickLogDialogItem(logDialog)}
+                        onItemInvoked={logDialog => this.onClickLogDialogItem(logDialog)}
                     />
                 </>
                 <ChatSessionModal


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing bug

#### What's the new behavior?
None

#### How does this change work?
Uses proper handler for item invocation. 

Seems this bug was also introduced here:
https://github.com/microsoft/conversationlearner/commit/6ac851b5635c66d11471a3d47ba5fb19b41aa596#diff-96045679718e9969df9ad055153589e3R498