### PR TITLE
fix: prevent crash when multivalue is removed for condition

### DIFF
--- a/packages/ui/src/Utils/actionCondition.ts
+++ b/packages/ui/src/Utils/actionCondition.ts
@@ -5,6 +5,7 @@
 import * as CLM from '@conversationlearner/models'
 import * as OF from 'office-ui-fabric-react'
 import produce from 'immer'
+import { PreBuilts } from 'src/types'
 
 export interface IConditionalTag extends OF.ITag {
     condition: CLM.Condition | null
@@ -164,4 +165,25 @@ export const getUpdatedActionsUsingCondition = (actions: CLM.ActionBase[], exist
 
         return actionsUsingCondition
     }, [])
+}
+
+/**
+ * Given entity return true if entity can be used in condition false otherwise
+ */
+export const isEntityAllowedInCondition = (entity: CLM.EntityBase): boolean => {
+    if (entity.entityType === CLM.EntityType.ENUM) {
+        return true
+    }
+
+    if (entity.entityType === CLM.EntityType.LUIS
+        && entity.resolverType === PreBuilts.Number
+        && entity.isResolutionRequired === true) {
+        return true
+    }
+
+    if (entity.isMultivalue === true) {
+        return true
+    }
+
+    return false
 }

--- a/packages/ui/src/Utils/actionCondition.ts
+++ b/packages/ui/src/Utils/actionCondition.ts
@@ -5,7 +5,7 @@
 import * as CLM from '@conversationlearner/models'
 import * as OF from 'office-ui-fabric-react'
 import produce from 'immer'
-import { PreBuilts } from 'src/types'
+import { PreBuilts } from '../types'
 
 export interface IConditionalTag extends OF.ITag {
     condition: CLM.Condition | null

--- a/packages/ui/src/components/modals/ConditionModal.tsx
+++ b/packages/ui/src/components/modals/ConditionModal.tsx
@@ -9,27 +9,8 @@ import * as CLM from '@conversationlearner/models'
 import { injectIntl, InjectedIntlProps } from 'react-intl'
 import { FM } from '../../react-intl-messages'
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning'
-import { PreBuilts } from 'src/types'
-import { conditionDisplay, convertConditionToConditionalTag, isConditionEqual } from '../../Utils/actionCondition'
+import { conditionDisplay, convertConditionToConditionalTag, isConditionEqual, isEntityAllowedInCondition } from '../../Utils/actionCondition'
 import './ConditionModal.css'
-
-const entityIsAllowedInCondition = (entity: CLM.EntityBase): boolean => {
-    if (entity.entityType === CLM.EntityType.ENUM) {
-        return true
-    }
-
-    if (entity.entityType === CLM.EntityType.LUIS
-        && entity.resolverType === PreBuilts.Number
-        && entity.isResolutionRequired === true) {
-        return true
-    }
-
-    if (entity.isMultivalue === true) {
-        return true
-    }
-
-    return false
-}
 
 interface EntityOption extends OF.IDropdownOption {
     data: CLM.EntityBase
@@ -105,7 +86,7 @@ type Props = InjectedIntlProps
 const Component: React.FC<Props> = (props) => {
     // Entity Dropdown
     const entityOptions = props.entities
-        .filter(entityIsAllowedInCondition)
+        .filter(isEntityAllowedInCondition)
         .map(e => convertEntityToDropdownOption(e))
         .sort((a, b) => a.text.localeCompare(b.text))
 

--- a/packages/ui/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
+++ b/packages/ui/src/components/modals/EntityCreatorEditor/EntityCreatorContainer.tsx
@@ -17,7 +17,7 @@ import { withRouter } from 'react-router-dom'
 import { RouteComponentProps } from 'react-router'
 import Component, { IEnumValueForDisplay } from './EntityCreatorComponent'
 import { autobind } from 'core-decorators'
-import { getUniqueConditions, getUpdatedActionsUsingCondition } from 'src/Utils/actionCondition'
+import { getUniqueConditions, getUpdatedActionsUsingCondition, isEntityAllowedInCondition } from 'src/Utils/actionCondition'
 import { NONE_RESOLVER_KEY } from '../../../types/const'
 
 const entityNameMaxLength = 30
@@ -30,6 +30,7 @@ const initState: ComponentState = {
     entityResolverVal: NONE_RESOLVER_KEY,
     isPrebuilt: false,
     isMultivalueVal: false,
+    isMultiValueDisabled: false,
     isNegatableVal: false,
     isResolutionRequired: false,
     enumValues: [],
@@ -54,6 +55,7 @@ interface ComponentState {
     entityResolverVal: string
     isPrebuilt: boolean
     isMultivalueVal: boolean
+    isMultiValueDisabled: boolean
     isNegatableVal: boolean
     isResolutionRequired: boolean
     enumValues: (CLM.EnumValue | null)[]
@@ -180,12 +182,15 @@ class Container extends React.Component<Props, ComponentState> {
                         ? NONE_RESOLVER_KEY
                         : nextProps.entity.resolverType
 
+                    const isMultiValueDisabled = this.isMultiValueDisabled(nextProps.entity, this.props.actions)
+
                     this.setState({
                         entityNameVal: nextProps.entity.entityName,
                         entityTypeVal: entityType,
                         entityResolverVal: resolverType,
                         isPrebuilt: isPrebuilt,
                         isMultivalueVal: nextProps.entity.isMultivalue,
+                        isMultiValueDisabled,
                         isNegatableVal: nextProps.entity.isNegatible,
                         isResolutionRequired: nextProps.entity.isResolutionRequired,
                         title: nextProps.intl.formatMessage({
@@ -331,6 +336,13 @@ class Container extends React.Component<Props, ComponentState> {
         }
 
         return newOrEditedEntity
+    }
+
+    isMultiValueDisabled(entity: CLM.EntityBase, actions: CLM.ActionBase[]) {
+        // If entity is already used in condition and changing multivalue to false would prevent entity from being valid in condition
+        const entityWithMultiValueFalse: CLM.EntityBase = { ...entity, isMultivalue: false }
+        return actions.some(a => a.requiredConditions.some(condition => condition.entityId === entity.entityId)) === true
+            && isEntityAllowedInCondition(entityWithMultiValueFalse) === false
     }
 
     @autobind
@@ -865,7 +877,7 @@ class Container extends React.Component<Props, ComponentState> {
             onKeyDownName={this.onKeyDownName}
 
             isMultiValue={this.state.isMultivalueVal}
-            isMultiValueDisabled={false}
+            isMultiValueDisabled={this.state.isMultiValueDisabled}
             onChangeMultiValue={this.onChangeMultivalue}
 
             isNegatable={this.state.isNegatableVal}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing bug

#### What's the new behavior?
Disables multi value when removal of multi value would invalidate condition.

#### How does this change work?
Shares computation about which entities are valid for conditoins and shares it across action modal
