### PR TITLE
fix: get app for change_model actions

### DIFF
--- a/packages/sdk/src/CLRunner.ts
+++ b/packages/sdk/src/CLRunner.ts
@@ -1191,6 +1191,7 @@ export class CLRunner {
                     break
                 }
                 case CLM.ActionTypes.CHANGE_MODEL: {
+                    app = await clRecognizeResult.state.BotState.GetApp()
                     const changeModelAction = new CLM.ChangeModelAction(clRecognizeResult.scoredAction as any)
                     sessionId = await clRecognizeResult.state.BotState.GetSessionIdAndSetConversationId(conversationReference)
                     actionResult = await this.TakeChangeModelAction(


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing bug with CHANGE_MODEL logs

#### What's the new behavior?
Now properly ends session when used in non-teach (log) scenarios

#### How does this change work?
Assigns `app` so the condition for session deletion is met