### PR TITLE
fix: hide action types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,9 @@
         "docs/**/*": true,
         "build/**/*": true,
         "lib/**/*": true,
+        "dist/**/*": true,
     },
     "editor.formatOnSave": true,
-    "typescript.format.semicolons": "remove"
+    "typescript.format.semicolons": "remove",
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/packages/models/src/Action.ts
+++ b/packages/models/src/Action.ts
@@ -14,7 +14,6 @@ export enum ActionTypes {
   SET_ENTITY = 'SET_ENTITY',
   DISPATCH = 'DISPATCH',
   CHANGE_MODEL = 'CHANGE_MODEL',
-  REMOTE_WORKFLOW = 'REMOTE_WORKFLOW',
 }
 
 export enum ConditionType {

--- a/packages/ui/src/components/modals/ActionCreatorEditor/ActionCreatorEditor.tsx
+++ b/packages/ui/src/components/modals/ActionCreatorEditor/ActionCreatorEditor.tsx
@@ -134,9 +134,9 @@ const convertEntityToConditionalTags = (entity: CLM.EntityBase, expand = true): 
 }
 
 // Returns deduplicated array of conditions currently used as required or negative conditions.
-const conditionalEntityTags = (entities: CLM.EntityBase[], actionz: CLM.ActionBase[]): IConditionalTag[] => {
+const conditionalEntityTags = (entities: CLM.EntityBase[], actions: CLM.ActionBase[]): IConditionalTag[] => {
     // Might have duplicates since different actions can have same conditions
-    const actionConditionTags = actionz
+    const actionConditionTags = actions
         .map(a => [...a.requiredConditions, ...a.negativeConditions])
         .reduce((a, b) => [...a, ...b], [])
         .map(c => convertConditionToConditionalTag(c, entities))
@@ -235,7 +235,7 @@ const tryCreateSlateValue = (actionType: string, slotName: string, content: obje
     }
 }
 
-const actionTypeOptions = (Object.values(CLM.ActionTypes) as string[])
+const actionTypeOptions = Object.values<string>(CLM.ActionTypes)
     .map<OF.IDropdownOption>(actionTypeString => {
         return {
             key: actionTypeString,
@@ -1785,6 +1785,17 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
             ? this.props.actions.find(a => a.actionId === this.state.repromptActionId)
             : undefined
 
+        const isDispatcherFeatureEnabled = Util.isFeatureEnabled(this.props.settings.features, FeatureStrings.DISPATCHER)
+        const availableActionTypeOptions = actionTypeOptions
+            .filter(actionTypeOption => {
+                if (isDispatcherFeatureEnabled === false
+                    && actionTypeOption.key === CLM.ActionTypes.DISPATCH) {
+                    return false
+                }
+
+                return true
+            })
+
         return (
             <OF.Modal
                 isOpen={this.props.open}
@@ -1800,7 +1811,7 @@ class ActionCreatorEditor extends React.Component<Props, ComponentState> {
                         <TC.Dropdown
                             data-testid="dropdown-action-type"
                             label="Action Type"
-                            options={actionTypeOptions}
+                            options={availableActionTypeOptions}
                             onChange={(event, actionTypeOption) => this.onChangeActionType(actionTypeOption)}
                             selectedKey={this.state.selectedActionTypeOptionKey}
                             disabled={disabled}


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Neither, removing display of action types in preparation for release.

#### What's the new behavior?
None

#### How does this change work?
Remotes `REMOTE_WORKFLOW` and hides `DISPATCH` with dispatch feature.

Should note this is only presentational and dispatch logic is still there because it's to mixed in to remove.  We'd need to design and entire plugin architecture to do that.
