### PR TITLE
fix: Plumb appId from .cl import files through to app creation request

### DIFF
--- a/packages/models/src/AppDefinition.ts
+++ b/packages/models/src/AppDefinition.ts
@@ -7,6 +7,7 @@ import { ActionBase } from './Action'
 import { TrainDialog } from './TrainDialog'
 
 export interface AppDefinition {
+  appId?: string
   entities: EntityBase[]
   actions: ActionBase[]
   trainDialogs: TrainDialog[]

--- a/packages/ui/src/actions/appActions.ts
+++ b/packages/ui/src/actions/appActions.ts
@@ -86,8 +86,14 @@ export const createApplicationThunkAsync = (userId: string, application: CLM.App
         const clClient = ClientFactory.getInstance(AT.CREATE_APPLICATION_ASYNC)
         try {
             dispatch(createApplicationAsync(userId, application))
-            const { appId, ...appToSend } = application
-            const newApp = await clClient.appsCreate(userId, appToSend as CLM.AppBase)
+
+            let appToSend = application
+            // If appId is set in the app definition, use it.
+            if (source?.appId && source.appId !== "") {
+                appToSend.appId = source.appId
+            }
+
+            const newApp = await clClient.appsCreate(userId, appToSend)
 
             if (source) {
                 await clClient.sourcepost(newApp.appId, source)


### PR DESCRIPTION
Plumbs `appId` through from `.cl` file to the `CreateApp` request.