### PR TITLE
fix: resolve truncation issue when exporting transcripts

### DIFF
--- a/packages/ui/src/components/modals/ExportChoice.tsx
+++ b/packages/ui/src/components/modals/ExportChoice.tsx
@@ -64,7 +64,7 @@ class ExportChoice extends React.Component<Props, ComponentState> {
         transcripts.forEach(t => {
             const content = JSON.stringify(t.activities)
             // const blob = new Blob([JSON.stringify(t.activities)], { type: "text/plain;charset=utf-8" })
-            zip.addFile(`${CLM.ModelUtils.generateGUID()}.transcript`, Buffer.alloc(content.length, content))
+            zip.addFile(`${CLM.ModelUtils.generateGUID()}.transcript`, Buffer.from(content))
         })
         const zipBuffer = zip.toBuffer()
         const zipBlob = new Blob([zipBuffer])


### PR DESCRIPTION
using Buffer.from(...) instead of Buffer.alloc(...) to fix the truncation issue. The encoding of string is utf8 and content.length should be number of bytes when calling into Buffer.alloc(...). 