### PR TITLE
fix: float conditions are not calculated properly

### DIFF
--- a/packages/sdk/src/Utils.ts
+++ b/packages/sdk/src/Utils.ts
@@ -308,7 +308,7 @@ const findNumberFromFilledEntity = (filledEntity: CLM.FilledEntity, isMultivalue
     const valueString: string | undefined = (filledEntity?.values?.[0]?.resolution as any)?.value
 
     const value = valueString
-        ? parseInt(valueString, 10)
+        ? parseFloat(valueString)
         : undefined
 
     return value

--- a/packages/ui/src/Utils/actionCondition.ts
+++ b/packages/ui/src/Utils/actionCondition.ts
@@ -103,7 +103,7 @@ export const findNumberFromMemory = (memory: CLM.Memory, isMultivalue: boolean):
     const valueString: string | undefined = (memory?.entityValues?.[0]?.resolution as any).value
 
     return valueString
-        ? parseInt(valueString, 10)
+        ? parseFloat(valueString)
         : undefined
 }
 


### PR DESCRIPTION
Numeric values were being being parse as ints causing conditions with floats to fail