### PR TITLE
Add source name text input next to add transcript button

### DIFF
--- a/packages/ui/src/Utils/obiUtils.tsx
+++ b/packages/ui/src/Utils/obiUtils.tsx
@@ -268,7 +268,7 @@ export async function trainDialogFromTranscriptImport(
                 if (activity.channelData?.PredictedEntities) {
                     nextFilledEntities = Util.deepCopy(nextFilledEntities)
 
-                    for (const predictedEntity  of activity.channelData?.PredictedEntities as CLM.PredictedEntity[]) {
+                    for (const predictedEntity of activity.channelData?.PredictedEntities as CLM.PredictedEntity[]) {
                         const memoryValue: CLM.MemoryValue = {
                             userText: predictedEntity.entityText,
                             displayText: predictedEntity.entityText,
@@ -858,7 +858,7 @@ export function findActionFromHashText(hashText: string, actions: CLM.ActionBase
     return matchedActions[0]
 }
 
-// Transcripts are partials of partials of BB.Activity, so RecusivePartial
+// Transcripts are partials of partials of BB.Activity, so RecursivePartial
 export function areTranscriptsEqual(transcript1: Util.RecursivePartial<BB.Activity>[], transcript2: Util.RecursivePartial<BB.Activity>[], excessOk: boolean = false): boolean {
     if (!excessOk && transcript1.length !== transcript2.length) {
         return false
@@ -870,11 +870,11 @@ export function areTranscriptsEqual(transcript1: Util.RecursivePartial<BB.Activi
         throw new Error("Not a valid transcript. Conversation not defined")
     }
     if (transcript1[0].conversation.id !== transcript2[0].conversation.id) {
-        throw new Error("Not a valid comparison.  ConversationIds do not match.")
+        throw new Error("Not a valid comparison. ConversationIds do not match.")
     }
-    if (transcript1[0].channelId === transcript2[0].channelId) {
-        throw new Error("Not a valid comparison.  Same channel.")
-    }
+    // if (transcript1[0].channelId === transcript2[0].channelId) {
+    //     throw new Error("Not a valid comparison. Same channel.")
+    // }
     for (let i = 0; i < Math.min(transcript1.length, transcript2.length); i = i + 1) {
         const activity1 = transcript1[i]
         const activity2 = transcript2[i]

--- a/packages/ui/src/components/modals/TranscriptComparisons.tsx
+++ b/packages/ui/src/components/modals/TranscriptComparisons.tsx
@@ -132,11 +132,13 @@ class TranscriptComparisons extends React.Component<Props, ComponentState> {
                                     : -1
                                 }
                                 onChange={this.onChangeCompareSource}
-                                options={(this.props.testSet?.sourceNames ?? [])
-                                    .map<OF.IDropdownOption>((tag, i) => ({
-                                        key: i,
-                                        text: tag
-                                    }))
+                                options={this.props.testSet
+                                    ? this.props.testSet.sourceNames
+                                        .map<OF.IDropdownOption>((tag, i) => ({
+                                            key: i,
+                                            text: tag
+                                        }))
+                                    : []
                                 }
                             />
                         </div>

--- a/packages/ui/src/components/modals/TranscriptComparisons.tsx
+++ b/packages/ui/src/components/modals/TranscriptComparisons.tsx
@@ -132,13 +132,11 @@ class TranscriptComparisons extends React.Component<Props, ComponentState> {
                                     : -1
                                 }
                                 onChange={this.onChangeCompareSource}
-                                options={this.props.testSet
-                                    ? this.props.testSet.sourceNames
-                                        .map<OF.IDropdownOption>((tag, i) => ({
-                                            key: i,
-                                            text: tag
-                                        }))
-                                    : []
+                                options={(this.props.testSet?.sourceNames ?? [])
+                                    .map<OF.IDropdownOption>((tag, i) => ({
+                                        key: i,
+                                        text: tag
+                                    }))
                                 }
                             />
                         </div>

--- a/packages/ui/src/components/modals/TranscriptList.tsx
+++ b/packages/ui/src/components/modals/TranscriptList.tsx
@@ -15,6 +15,7 @@ import './TranscriptRatings.css'
 
 interface ComponentState {
     transcriptColumns: IRenderableColumn[]
+    importSourceName: string
 }
 
 interface RenderData {
@@ -77,6 +78,7 @@ class TranscriptList extends React.Component<Props, ComponentState> {
         super(props)
         this.state = {
             transcriptColumns: getColumns(this.props.intl),
+            importSourceName: ''
         }
     }
 
@@ -93,12 +95,26 @@ class TranscriptList extends React.Component<Props, ComponentState> {
 
     @autobind
     async onLoadTranscriptFiles(files: any): Promise<void> {
-        await this.props.onLoadTranscriptFiles(files)
+        await this.props.onLoadTranscriptFiles(files, this.state.importSourceName)
+
+        // Reset source name
+        this.setState({
+            importSourceName: ''
+        })
 
         // If still open, clear input so user can reload same file
         let fileInput = (this.loadTranscriptsFileInput as HTMLInputElement)
         {
             fileInput.value = ""
+        }
+    }
+
+    @autobind
+    onChangeSourceName(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string): void {
+        if (typeof newValue === 'string') {
+            this.setState({
+                importSourceName: newValue
+            })
         }
     }
 
@@ -184,6 +200,12 @@ class TranscriptList extends React.Component<Props, ComponentState> {
                                 iconProps={{ iconName: 'BulkUpload' }}
                                 onClick={() => this.loadLGFileInput.click()}
                             />
+                            <OF.TextField
+                                label={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME)}
+                                value={this.state.importSourceName}
+                                onChange={this.onChangeSourceName}
+                                styles={{ wrapper: { display: 'flex', gridGap: '0.5rem', width: '200px', alignItems: 'baseline' } }}
+                            />
                         </div>
                         <div className="cl-modal-buttons_primary">
                             <OF.DefaultButton
@@ -211,7 +233,7 @@ class TranscriptList extends React.Component<Props, ComponentState> {
 export interface ReceivedProps {
     testSet: Test.TestSet | undefined
     onView: (compareType: Test.ComparisonResultType, comparePivot?: string, compareSource?: string) => void
-    onLoadTranscriptFiles: (transcriptFiles: any) => Promise<void>
+    onLoadTranscriptFiles: (transcriptFiles: any, importSourceName?: string) => Promise<void>
     onLoadLGFiles: (lgFiles: any) => Promise<void>
     onTest: () => Promise<void>
 }

--- a/packages/ui/src/components/modals/TranscriptList.tsx
+++ b/packages/ui/src/components/modals/TranscriptList.tsx
@@ -188,6 +188,13 @@ class TranscriptList extends React.Component<Props, ComponentState> {
                     }
                     <div className="cl-modal-buttons cl-modal_footer">
                         <div className="cl-modal-buttons_secondary">
+                            <OF.TextField
+                                label={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME)}
+                                placeholder={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME_PLACEHOLDER)}
+                                value={this.state.importSourceName}
+                                onChange={this.onChangeSourceName}
+                                styles={{ wrapper: { display: 'flex', gridGap: '0.5rem', width: '200px', alignItems: 'baseline' } }}
+                            />
                             <OF.PrimaryButton
                                 ariaDescription={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS)}
                                 text={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS)}
@@ -199,12 +206,6 @@ class TranscriptList extends React.Component<Props, ComponentState> {
                                 text={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_BUTTON_ADD_LG)}
                                 iconProps={{ iconName: 'BulkUpload' }}
                                 onClick={() => this.loadLGFileInput.click()}
-                            />
-                            <OF.TextField
-                                label={Util.formatMessageId(this.props.intl, FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME)}
-                                value={this.state.importSourceName}
-                                onChange={this.onChangeSourceName}
-                                styles={{ wrapper: { display: 'flex', gridGap: '0.5rem', width: '200px', alignItems: 'baseline' } }}
                             />
                         </div>
                         <div className="cl-modal-buttons_primary">

--- a/packages/ui/src/react-intl-messages.ts
+++ b/packages/ui/src/react-intl-messages.ts
@@ -649,6 +649,7 @@ export enum FM {
     TRANSCRIPTLIST_BUTTON_VIEW = 'TranscriptList.button.view',
     TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS = 'TranscriptList.button.AddTranscripts',
     TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME = 'TranscriptList.textInput.sourceName',
+    TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME_PLACEHOLDER = 'TranscriptList.textInput.sourceNamePlaceholder',
     TRANSCRIPTLIST_BUTTON_TEST_MODEL = 'TranscriptList.button.NewTest',
 
     // TranscriptTestPicker
@@ -1322,6 +1323,7 @@ export default {
         [FM.TRANSCRIPTLIST_BUTTON_VIEW]: 'View Transcripts',
         [FM.TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS]: 'Add Transcripts',
         [FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME]: 'Source Name',
+        [FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME_PLACEHOLDER]: 'PVA, Xbox, etc',
         [FM.TRANSCRIPTLIST_BUTTON_TEST_MODEL]: 'Test Model',
 
         // TranscriptTestPicker

--- a/packages/ui/src/react-intl-messages.ts
+++ b/packages/ui/src/react-intl-messages.ts
@@ -648,6 +648,7 @@ export enum FM {
     TRANSCRIPTLIST_BUTTON_ADD_LG = 'TranscriptList.button.add',
     TRANSCRIPTLIST_BUTTON_VIEW = 'TranscriptList.button.view',
     TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS = 'TranscriptList.button.AddTranscripts',
+    TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME = 'TranscriptList.textInput.sourceName',
     TRANSCRIPTLIST_BUTTON_TEST_MODEL = 'TranscriptList.button.NewTest',
 
     // TranscriptTestPicker
@@ -1320,6 +1321,7 @@ export default {
         [FM.TRANSCRIPTLIST_BUTTON_ADD_LG]: 'Add LG',
         [FM.TRANSCRIPTLIST_BUTTON_VIEW]: 'View Transcripts',
         [FM.TRANSCRIPTLIST_BUTTON_ADD_TRANSCRIPTS]: 'Add Transcripts',
+        [FM.TRANSCRIPTLIST_TEXTFIELD_SOURCE_NAME]: 'Source Name',
         [FM.TRANSCRIPTLIST_BUTTON_TEST_MODEL]: 'Test Model',
 
         // TranscriptTestPicker

--- a/packages/ui/src/routes/Apps/App/Testing.tsx
+++ b/packages/ui/src/routes/Apps/App/Testing.tsx
@@ -207,12 +207,7 @@ class Testing extends React.Component<Props, ComponentState> {
                         if (transcriptValidationTurn.inputText !== "") {
                             turnValidations.push(transcriptValidationTurn)
                         }
-
-                        transcriptValidationTurn = {
-                            inputText: activity.text,
-                            apiResults: [],
-                            predictedEntities: activity.channelData?.PredictedEntities ?? []
-                        }
+                        transcriptValidationTurn = { inputText: activity.text, apiResults: [], predictedEntities: activity.channelData["PredictedEntities"]} 
                     }
                     else if (activity.from.role === "bot") {
                         if (transcriptValidationTurn) {

--- a/packages/ui/src/routes/Apps/App/Testing.tsx
+++ b/packages/ui/src/routes/Apps/App/Testing.tsx
@@ -102,7 +102,7 @@ class Testing extends React.Component<Props, ComponentState> {
     }
 
     @autobind
-    async onLoadTranscriptFiles(transcriptFiles: any): Promise<void> {
+    async onLoadTranscriptFiles(transcriptFiles: any, importSourceName?: string): Promise<void> {
         if (transcriptFiles.length > 0) {
 
             try {
@@ -111,7 +111,7 @@ class Testing extends React.Component<Props, ComponentState> {
                     : this.newTestSet()
 
                 this.props.spinnerAdd()
-                await testSet.addTranscriptFiles(transcriptFiles)
+                await testSet.addTranscriptFiles(transcriptFiles, importSourceName)
 
                 await Util.setStateAsync(this, { testSet })
 
@@ -195,9 +195,8 @@ class Testing extends React.Component<Props, ComponentState> {
 
             for (let activity of testItem.transcript) {
 
-                if (activity.channelData["InitialFilledEntities"]) {
-                    initialFilledEntities = activity.channelData["InitialFilledEntities"]
-                }
+                initialFilledEntities = activity.channelData?.InitialFilledEntities ?? []
+
                 // TODO: Handle conversation updates
                 if (!activity.type || activity.type === "message") {
                     if (activity.text === "END_SESSION") {
@@ -208,7 +207,12 @@ class Testing extends React.Component<Props, ComponentState> {
                         if (transcriptValidationTurn.inputText !== "") {
                             turnValidations.push(transcriptValidationTurn)
                         }
-                        transcriptValidationTurn = { inputText: activity.text, apiResults: [], predictedEntities: activity.channelData["PredictedEntities"]} 
+
+                        transcriptValidationTurn = {
+                            inputText: activity.text,
+                            apiResults: [],
+                            predictedEntities: activity.channelData?.PredictedEntities ?? []
+                        }
                     }
                     else if (activity.from.role === "bot") {
                         if (transcriptValidationTurn) {

--- a/packages/ui/src/routes/Apps/App/Testing.tsx
+++ b/packages/ui/src/routes/Apps/App/Testing.tsx
@@ -11,7 +11,7 @@ import * as OBIUtils from '../../../Utils/obiUtils'
 import * as Test from '../../../types/TestObjects'
 import actions from '../../../actions'
 import TranscriptRatings from '../../../components/modals/TranscriptRatings'
-import TranscriptComparisions from '../../../components/modals/TranscriptComparisons'
+import TranscriptComparisons from '../../../components/modals/TranscriptComparisons'
 import TranscriptList from '../../../components/modals/TranscriptList'
 import FormattedMessageId from '../../../components/FormattedMessageId'
 import CompareDialogsModal from '../../../components/modals/CompareDialogsModal'
@@ -647,7 +647,7 @@ class Testing extends React.Component<Props, ComponentState> {
                         <OF.PivotItem
                             linkText={Util.formatMessageId(this.props.intl, FM.TESTING_PIVOT_COMPARISON)}
                         >
-                            <TranscriptComparisions
+                            <TranscriptComparisons
                                 testSet={this.state.testSet}
                                 onCompare={this.onCompare}
                                 onView={this.onView}

--- a/packages/ui/src/types/TestObjects.ts
+++ b/packages/ui/src/types/TestObjects.ts
@@ -244,7 +244,8 @@ export class TestSet {
                                         ? ComparisonResultType.REPRODUCED
                                         : ComparisonResultType.CHANGED
                                 }
-                                catch {
+                                catch (e) {
+                                    console.error(`Error when comparing all transcripts: `, e)
                                     result = ComparisonResultType.INVALID_TRANSCRIPT
                                 }
 

--- a/packages/ui/src/types/TestObjects.ts
+++ b/packages/ui/src/types/TestObjects.ts
@@ -138,19 +138,21 @@ export class TestSet {
         this.lgItems = await OBIUtils.lgMapFromLGFiles(lgFiles, this.lgItems)
     }
 
-    async addTranscriptFiles(transcriptFiles: File[]): Promise<void> {
+    async addTranscriptFiles(transcriptFiles: File[], importSourceName?: string): Promise<void> {
         for (const file of transcriptFiles) {
             let fileContent = await Util.readFileAsync(file)
 
             const inputData = JSON.parse(fileContent)
 
             // File could be list of Activities or Activity list in Transcript property
-            const transcript: BB.Activity[] = inputData.Transcript 
+            const transcript: BB.Activity[] = inputData.Transcript
                 ? inputData.Transcript
                 : inputData
 
             let transcriptUsesLG = OBIUtils.usesLG(transcript)
-            const sourceName = this.sourceName(transcript)
+            const sourceName = (typeof importSourceName === 'string' && importSourceName !== '')
+                ? importSourceName
+                : this.sourceName(transcript)
             const conversationId = this.conversationId(transcript)
 
             const item: TestItem = {

--- a/packages/ui/src/types/TestObjects.ts
+++ b/packages/ui/src/types/TestObjects.ts
@@ -244,8 +244,7 @@ export class TestSet {
                                         ? ComparisonResultType.REPRODUCED
                                         : ComparisonResultType.CHANGED
                                 }
-                                catch (e) {
-                                    console.error(`Error when comparing all transcripts: `, e)
+                                catch {
                                     result = ComparisonResultType.INVALID_TRANSCRIPT
                                 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature.

#### What's the new behavior?

Using the new text input, you can now choose the source name transcripts will be imported as instead if always being the channelId of the first activity.

#### How does this change work?

If the text input is non empty on import, use that value as source name
Otherwise, use default (channelId)

https://microsoft.sharepoint.com/:w:/t/convsysresearch/EURKFrqB6f9Jsw9fGcQD03kBEwOSiLuTss0wSHkjaPseUg?e=kxOgE0

### Gif if change

![transcriptComparison](https://user-images.githubusercontent.com/2856501/136992710-fe321201-19b0-4bf9-b67d-69aa5435fae5.gif)

### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @